### PR TITLE
feat(skills): regression-triage + send-gchat-message decomposition

### DIFF
--- a/claude/skills/README.md
+++ b/claude/skills/README.md
@@ -13,11 +13,57 @@
 | **golang-pre-commit-tests** | Before committing in a Go repo: run the full internal test suite (e.g. `go test ./internal/...`) so commits are green. |
 | **open-pr** | When opening a pull request: always create as draft, include Jira link, fill PR template. |
 | **pr-ready** | When marking a PR ready for review: un-draft, add `vendasta/meerkats` reviewer, append `@vendasta/meerkats` to body, post in team GChat PR channel. |
-| **notify-pr-channels** | When a build passes or notifying the team: post to personal team PR channel (AT Craig & Daniel) and snapcats channel. Channel URLs and webhook setup documented here. |
+| **notify-pr-channels** | When a build passes or notifying the team: post to personal team PR channel (AT Craig & Daniel) and any `@vendasta/<team>` channels in the PR body. Delegates delivery to **send-gchat-message**. |
+| **send-gchat-message** | Low-level primitive: post a message to any Google Chat space/team, resolving space IDs / `@vendasta/<team>` handles / slugs. Owns Chat auth + the `TEAM_CHANNELS` map. Used by notify-pr-channels and regression-triage. |
+| **regression-triage** | When a side problem (e.g. from **deploy-monitor**) looks like a regression from an earlier PR: attribute it to the introducing PR (confirm-gate — first blame is often wrong), then route to **alert** the owning team or **fix** it (hands off to the dev flow below). |
 | **gcp-ci-watch** | When watching CI/CD for a branch: poll GCP Cloud Build directly (not GitHub checks). Report green/failure. Only merge if explicitly asked. On failure, always diagnose logs, fix, push, and re-watch — don't wait to be asked. |
 | **wsu** | When creating a new Weekly Status Update page: compute the correct title, gather data from GitHub/GChat/git, run the questionnaire, and create the Confluence page. |
 | **wsu-note** | When the user wants to capture a WSU-worthy moment mid-week. Appends a timestamped note to the weekly file for `/wsu` to pick up at compile time. |
 
 **Refactors:** Use at least 2–3 commits: (1) add new code + tests → commit & push, (2) switch callers to new code → commit & push, (3) remove old code → commit & push. See **green-commits/SKILL.md** and **plan-implementation-commits/SKILL.md** for details.
+
+## Skill flow — which kicks off which
+
+How the develop → ship → deploy → triage skills chain together. `deploy-monitor`
+lives in the `vendasta-dev-agent-toolkit` plugin; everything else is in this dir.
+This is the chain `regression-triage`'s fix branch hands back into.
+
+```mermaid
+flowchart TD
+    subgraph Develop
+        WT[git-worktree-jira-branch]
+        PLAN{"/plan ?"}
+        PCW[plan-commit-to-worktree]
+        WORK["do the work<br/>green-commits / plan-implementation-commits<br/>+ golang-pre-commit-tests + commit-preferences"]
+    end
+    subgraph Ship
+        DRAFT[open-pr - draft]
+        ARC[open-in-arc / pr-studio-open-in-arc]
+        READY[pr-ready]
+        NOTIFY[notify-pr-channels]
+        GCHAT[send-gchat-message]
+        FB[pr-feedback-watcher]
+        SYNC[sync-base]
+        MERGE[merge-pr]
+    end
+    subgraph DeployTriage["Deploy & Triage"]
+        DM[["deploy-monitor (plugin)"]]
+        RT[regression-triage]
+        JIRA[(Jira bug)]
+    end
+
+    WT --> PLAN
+    PLAN -- yes --> PCW --> WORK
+    PLAN -- no --> WORK
+    WORK --> DRAFT --> ARC --> READY
+    READY --> NOTIFY --> GCHAT
+    READY --> FB
+    FB --> SYNC --> MERGE --> DM
+    DM -- side-finding --> RT
+    RT -- alert-only --> GCHAT
+    RT -- alert-only --> JIRA
+    RT -- fix - Jira first --> JIRA
+    RT -- fix --> WT
+```
 
 **Cursor:** If these skills are not being applied in new chats, enable **Agent Skills** in Cursor Settings → Rules (Import Settings), or add the key rules as **User Rules** in the same place so they are always in context.

--- a/claude/skills/notify-pr-channels/SKILL.md
+++ b/claude/skills/notify-pr-channels/SKILL.md
@@ -20,7 +20,10 @@ When a build passes or a PR is ready, the script always posts to the personal te
 | Warped Tour | https://chat.google.com/room/AAQANVVa_PA?cls=7 | External — posted when `@vendasta/warped-tour` in PR body |
 | Marketplace Institute of Technology | https://chat.google.com/room/AAAACpnkUis?cls=7 | External — posted when `@vendasta/marketplace-institute-of-technology` in PR body |
 
-To add a new external team: add their slug → space ID to `TEAM_CHANNELS` in `scripts/chat_post.py`.
+To add a new external team: add their slug → space ID to `TEAM_CHANNELS` in the
+[send-gchat-message](../send-gchat-message/SKILL.md) skill (`scripts/send_gchat.py`) —
+that map is the single source of truth. Unmapped teams are resolved live via
+`spaces.list` ("Team: <Name>"), so a missing entry degrades to a lookup, not a failure.
 
 ## When to notify
 
@@ -31,13 +34,19 @@ Only run this skill after the PR is marked ready for review. Do not notify chann
 Use the bundled script — no webhook URLs needed, auth is handled via OAuth:
 
 ```bash
+# Standard PR notification:
 python3 ~/.claude/skills/notify-pr-channels/scripts/chat_post.py "<PR_URL>" "<PR_TITLE>"
+
+# With an optional prefix line (e.g. context for why you're posting):
+python3 ~/.claude/skills/notify-pr-channels/scripts/chat_post.py "<PR_URL>" "<PR_TITLE>" "Found during deploy monitor for a different PR."
 ```
 
 The script:
 - Always posts to the personal team PR channel with @Craig Kumick and @Daniel Ngo mentions
 - Reads the PR body via `gh pr view` and posts to any external team channels whose `@vendasta/<slug>` appears in the body
-- Auth: refreshes OAuth token via GCP secret `google-chat-oauth-client-secret` (repcore-prod), cached at `~/.config/google-chat-cli/credentials-rw.json`
+- Optional 3rd arg is a prefix line prepended to every message
+- **Delegates auth + channel resolution to the [send-gchat-message](../send-gchat-message/SKILL.md) skill** (`scripts/send_gchat.py`) — it only owns the PR-specific message shape
+- Auth: OAuth token via GCP secret `google-chat-oauth-client-secret` (repcore-prod), cached at `~/.config/google-chat-cli/credentials-rw.json`
 
 ### Known user IDs (hardcoded in script)
 - Craig Kumick: `users/101609381686230694100`

--- a/claude/skills/notify-pr-channels/scripts/chat_post.py
+++ b/claude/skills/notify-pr-channels/scripts/chat_post.py
@@ -1,112 +1,65 @@
 #!/usr/bin/env python3
 """Post a PR notification to Google Chat channels.
 
+Always posts to the personal team PR channel (@mentions Craig + Daniel), then
+reads the PR body for @vendasta/<team> mentions and posts to those team channels.
+
+Auth, channel resolution, and the TEAM_CHANNELS map are delegated to the
+send-gchat-message skill's shared module (single source of truth) so this script
+only owns the PR-specific message shape.
+
 Usage:
-    python3 chat_post.py <pr_url> <pr_title>
+    chat_post.py <pr_url> <pr_title> [prefix]
 
-Always posts to:
-  - Personal team PR channel (AAAAIj8WMWc) — @mentions Craig and Daniel
-
-Also posts to any external team channels found by reading @vendasta/<team>
-mentions in the PR body via `gh pr view`. Add teams to TEAM_CHANNELS below.
-
-Auth: OAuth via GCP secret + cached refresh token at
-      ~/.config/google-chat-cli/credentials-rw.json
+`prefix` is an optional first line prepended to every message (e.g.
+"Found during deploy monitor for a different PR.").
 """
-import json, re, subprocess, sys, urllib.request, urllib.parse
-from pathlib import Path
+import os
+import re
+import subprocess
+import sys
 
-CLIENT_ID = "642433220657-955eqfa32mlb0o3koe8g4qmuv1ue414s.apps.googleusercontent.com"
-CREDS_FILE = Path('/Users/bhingston/.config/google-chat-cli/credentials-rw.json')
+# Reuse the shared Chat primitive (auth, post_message, resolve_target, TEAM_CHANNELS).
+sys.path.insert(0, os.path.expanduser('~/.claude/skills/send-gchat-message/scripts'))
+import send_gchat  # noqa: E402
 
-# Team members (Google Chat user IDs)
+# Team members (Google Chat user IDs) mentioned on the personal team channel.
 CRAIG_ID = "users/101609381686230694100"   # Craig Kumick
 DANIEL_ID = "users/107059066615888383168"  # Daniel Ngo
-
-# Always-posted spaces
-SPACES = {
-    'team': 'AAAAIj8WMWc',  # Personal team PR channel (always posted)
-}
-
-# External team slug → Google Chat space ID
-# Posted when @vendasta/<team> appears in the PR body.
-# Add new teams here as they're encountered.
-TEAM_CHANNELS = {
-    'snapcats':  'AAAAAHjNt6A',  # Snapcats channel
-    'snack-ops': 'AAAAjno8gDs',  # SnackOps channel
-    'phoenix':   'AAAAN_I9hG8',  # Phoenix team channel
-    'autobots':  'AAAAWOyaLAg',  # Autobots team channel
-    'np-easy':   'AAAAqGa-a8I',  # NP-Easy (CRMaaS) team channel
-    'warped-tour': 'AAQANVVa_PA',  # Warped Tour team channel
-    'marketplace-institute-of-technology': 'AAAACpnkUis',  # Marketplace Institute of Technology (MIT) team channel
-}
+TEAM_SPACE = "AAAAIj8WMWc"                  # personal team PR channel (always posted)
 
 
-def get_access_token():
-    client_secret = subprocess.run(
-        ['gcloud', 'secrets', 'versions', 'access', 'latest',
-         '--secret=google-chat-oauth-client-secret', '--project=repcore-prod'],
-        capture_output=True, text=True,
-    ).stdout.strip()
-    creds = json.loads(CREDS_FILE.read_text())
-    data = urllib.parse.urlencode({
-        'client_id': CLIENT_ID, 'client_secret': client_secret,
-        'refresh_token': creds['refresh_token'], 'grant_type': 'refresh_token',
-    }).encode()
-    resp = json.loads(urllib.request.urlopen(
-        urllib.request.Request('https://oauth2.googleapis.com/token', data=data, method='POST')
-    ).read())
-    return resp['access_token']
-
-
-def post_message(access_token, space_id, text):
-    body = json.dumps({'text': text}).encode()
-    req = urllib.request.Request(
-        f'https://chat.googleapis.com/v1/spaces/{space_id}/messages',
-        data=body, method='POST',
-    )
-    req.add_header('Authorization', f'Bearer {access_token}')
-    req.add_header('Content-Type', 'application/json')
-    try:
-        urllib.request.urlopen(req).read()
-        print(f"Posted to {space_id}")
-    except urllib.error.HTTPError as e:
-        print(f"Error posting to {space_id}: {e.code} {e.read().decode()[:300]}")
-
-
-def get_pr_team_spaces(pr_url):
-    """Read PR body via gh CLI and return any TEAM_CHANNELS spaces mentioned."""
+def get_pr_body(pr_url):
     result = subprocess.run(
         ['gh', 'pr', 'view', pr_url, '--json', 'body', '--jq', '.body'],
         capture_output=True, text=True,
     )
-    if result.returncode != 0:
-        return []
-    body = result.stdout
-    mentioned = re.findall(r'@vendasta/([\w-]+)', body)
-    spaces = []
-    for team in mentioned:
-        space = TEAM_CHANNELS.get(team)
-        if space:
-            spaces.append((team, space))
-    return spaces
+    return result.stdout if result.returncode == 0 else ''
 
 
 def main():
     if len(sys.argv) < 3:
-        print("Usage: chat_post.py <pr_url> <pr_title>")
+        print("Usage: chat_post.py <pr_url> <pr_title> [prefix]")
         sys.exit(1)
 
     pr_url, pr_title = sys.argv[1], sys.argv[2]
-    access_token = get_access_token()
+    prefix = (sys.argv[3].rstrip() + "\n") if len(sys.argv) > 3 and sys.argv[3].strip() else ""
+    token = send_gchat.get_access_token()
 
-    # Always post to team channel
-    post_message(access_token, SPACES['team'], f'{pr_title}\n{pr_url} <{CRAIG_ID}> <{DANIEL_ID}>')
+    # Always post to the personal team channel with Craig + Daniel mentions.
+    team_msg = f'{prefix}{pr_title}\n{pr_url} <{CRAIG_ID}> <{DANIEL_ID}>'
+    ok, err = send_gchat.post_message(token, TEAM_SPACE, team_msg)
+    print(f"{'Posted to' if ok else 'Error posting to'} team ({TEAM_SPACE})" + (f": {err}" if err else ''))
 
-    # Post to any external team channels mentioned in the PR body
-    for team, space_id in get_pr_team_spaces(pr_url):
-        print(f"Found @vendasta/{team} in PR body — posting to their channel")
-        post_message(access_token, space_id, f'{pr_title}\n{pr_url}')
+    # Post to any external team channels mentioned in the PR body.
+    for team in re.findall(r'@vendasta/([\w-]+)', get_pr_body(pr_url)):
+        space_id, how = send_gchat.resolve_target(team, token)
+        if not space_id:
+            print(f"Skipping @vendasta/{team}: no channel found ({how})")
+            continue
+        print(f"Found @vendasta/{team} in PR body — posting to their channel ({space_id})")
+        ok, err = send_gchat.post_message(token, space_id, f'{prefix}{pr_title}\n{pr_url}')
+        print(f"{'Posted to' if ok else 'Error posting to'} {team} ({space_id})" + (f": {err}" if err else ''))
 
 
 if __name__ == '__main__':

--- a/claude/skills/regression-triage/SKILL.md
+++ b/claude/skills/regression-triage/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: regression-triage
+description: When a side problem surfaces (e.g. during a deploy-monitor watch) that looks like a regression introduced by an earlier PR, attribute it to the PR that introduced it, then route to one of two outcomes — alert the owning team, or fix it. Use when a bug/panic/error is found that is NOT from the change currently being worked on and you need to find the responsible PR and act. Triggers: "find the PR that introduced this", "who broke this", "this panic isn't from my change", a deploy-monitor side-finding, or any attributed regression that needs an alert-or-fix decision.
+---
+
+# Regression Triage
+
+Takes a **finding** (a bug/panic/error, usually surfaced by `deploy-monitor`)
+and turns it into action: attribute it to the introducing PR, then either
+**alert** the owning team or **fix** it — in both cases posting the finding's
+context on the responsible PR.
+
+This skill is **standalone** — `deploy-monitor` surfaces a side-finding and
+*suggests* running this; it does not auto-invoke. Invoke it manually whenever you
+have a regression to attribute and act on.
+
+## Input: the finding
+
+Gather (from the deploy-monitor context or pasted in):
+- Error signature / stack frames with **file:line**
+- Prod evidence: occurrence count, **onset**, affected cohort, recovered-vs-fatal
+- What behaviour is affected and how bad (each occurrence = failed request? silent skip? crash?)
+
+## Phase 1 — Attribute (do NOT act yet)
+
+> Hard-won lesson: the first, most confident attribution is often **wrong**.
+> In the worked example the skill blamed PR #1527 on a narrow-window onset, opened
+> it in Arc, and built a watch — then had to fully retract it. A single skeptical
+> nudge flipped the conclusion. Earn the attribution before acting on it.
+
+1. **Establish true onset with a WIDE log window first (7–30d), not the deploy-watch window.**
+   A 24h watch window makes everything look like it "started today." Query the
+   error signature over weeks and find the real first occurrence. If the bug
+   predates the PR you suspect, that PR didn't introduce it.
+2. **Blame the EXACT faulting line, not the surrounding feature.** Use the helper:
+   ```bash
+   ~/.claude/skills/regression-triage/scripts/attribute_pr.sh <file> <line> [origin/master]
+   ```
+   It prints the commit, author/date, and PR(s). Treat it as an input, not the verdict.
+3. **Distinguish three different roles** — be explicit about which a PR played:
+   - *introduced the code path* (the feature exists because of it)
+   - *is the line that faults* (the actual deref / panic / bad branch)
+   - *widened the trigger* (made a latent bug reachable for more inputs)
+   The "introduced the code path" PR is frequently **not** the culprit.
+4. **Disprove each candidate.** For every hypothesis, find evidence that rules it
+   in or out (does that function ever return nil? does the repo ever return
+   `(nil, nil)`? when did the offending branch start being taken?). Don't stop at
+   the first plausible blame.
+5. Produce **ranked candidate PR(s) with the evidence chain** — and stop here.
+   No Arc, no comment, no branch until the gate confirms.
+
+## Phase 2 — Single review gate (catch misattribution here)
+
+Present everything at once and get one approval (use `AskUserQuestion`):
+- The attributed PR(s) + reasoning + onset evidence (so a wrong call is catchable)
+- The **drafted PR comment** (see template below)
+- The **owning team** + target Chat channel(s) — infer from CODEOWNERS for the
+  faulting file and/or `@vendasta/<team>` mentions / Jira tag on the introducing PR
+- The proposed **Jira project** + a draft bug (project inferred from the owning
+  team / the introducing PR's Jira tag; confirm or override)
+
+Ask the two routing decisions:
+- **Fix it** or **alert-only**?
+- **Create a Jira bug?** (Y/N, + board override)
+
+## Phase 3 — Post the PR comment (BOTH branches)
+
+Write the body to a file and use `gh pr comment <n> --body-file` (heredoc quoting
+breaks — always use a file). Template (from the worked example, which landed well):
+
+- **Bold lead heading** — what + where (+ "fix in #<n> (<TICKET>)" if fixing)
+- **How found** — ties it to the deploy-monitor origin ("While monitoring the #X deploy I found…")
+- **Root cause** — exact file:line call sites and the actual faulting line (e.g. the SDK deref)
+- **Why it went unnoticed** — happy path never hits it; affected cohort; rate ("~N/day since <date>")
+- **Provenance** — name the PR that introduced the code path vs the one that widened the trigger; be precise, don't over-claim
+- **Fix** — link the fix PR + Jira (fix branch), OR **de-escalation** ("No action needed here — flagging for context since the code originated in this PR.") (alert branch)
+
+## Phase 4a — Alert-only
+
+1. (If chosen) create the Jira bug via the Atlassian MCP `createJiraIssue` — project
+   from the gate, issue type **Bug**, description = finding summary + links to the
+   introducing PR / the PR comment.
+2. Notify the owning team via the **send-gchat-message** skill, resolving the team
+   to its channel and linking the PR comment. Use a prefix that ties it to the
+   finding's origin:
+   ```bash
+   ~/.claude/skills/send-gchat-message/scripts/send_gchat.py \
+     --targets "@vendasta/<team>" --message-file /tmp/alert.md
+   ```
+
+## Phase 4b — Fix → hand off to the existing dev flow
+
+Do **not** orchestrate the dev flow rigidly — kick it off and step back. It is a
+chain of existing skills that evolves over time (see the flow diagram in the repo
+README). Order:
+
+1. **Create the Jira bug FIRST** (before the branch) so the ticket key drives the
+   branch name. (`createJiraIssue`, project from the gate, type Bug; set sprint/assignee/status as you normally do.)
+2. **Branch off latest `origin/master`**, named from the ticket — via
+   `git-worktree-jira-branch` (or a plain branch if not using worktrees), e.g.
+   `<TICKET>/<short-desc>`.
+3. **Plan or not — your call:** run `/plan` for non-trivial fixes, or implement
+   directly for a small/obvious one. Then the work gets done with **small green
+   commits** (`green-commits` / `plan-implementation-commits`; run the repo's
+   pre-commit / `golang-pre-commit-tests` before each).
+4. **`open-pr`** (draft) → open in Arc (`open-in-arc`) for review.
+5. When ready: **`pr-ready`** (marks ready, adds reviewers, posts via `notify-pr-channels`).
+6. **`pr-feedback-watcher`** to watch + address feedback.
+7. On approvals + green: prompt to merge → **`merge-pr`**, which hands off to
+   **`deploy-monitor`** on the fix PR — closing the loop.
+
+### Guardrails for the fix (learned the hard way)
+
+- **Write every PR / issue / comment body to a file** and pass `--body-file`. Heredoc quoting in `gh pr create`/`comment` breaks on backticks/brackets.
+- **Never `--amend` or squash a commit already pushed to the PR without asking.** Default to appending a new commit; if the user wants intermediate history preserved, don't collapse it. (In the example, an `--amend` silently dropped a commit the user wanted kept and had to be reconstructed.)
+- **After `go generate`, the LSP cache is stale** — it'll report phantom "wrong arg count" on regenerated mocks. Trust `go build` / `go test`, not the LSP.
+- **Adding a param to a mocked interface:** `gomock` `DoAndReturn` callbacks compile but panic at runtime until their signatures are updated by hand — `go vet` won't catch it.
+- **Author-on-team PRs:** a requested reviewer may not surface via the GitHub API; rely on the `@vendasta/<team>` body mention to notify.
+
+## Relationship to other skills
+
+- `deploy-monitor` → surfaces the side-finding that triggers this skill.
+- `send-gchat-message` → delivers the alert (Phase 4a).
+- `notify-pr-channels` → used inside `pr-ready` on the fix branch (Phase 4b).
+- `merge-pr` → tail of the fix branch; hands back to `deploy-monitor`.

--- a/claude/skills/regression-triage/scripts/attribute_pr.sh
+++ b/claude/skills/regression-triage/scripts/attribute_pr.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Map a source line to the commit + PR that last touched it.
+#
+# Usage: attribute_pr.sh <file> <line> [git-ref]
+#   Run from inside the target repo. <git-ref> defaults to origin/master.
+#
+# This is an INPUT to attribution, not the answer. Blame tells you who last
+# touched a line — not necessarily the PR that made a latent bug reachable.
+# Always corroborate with the bug's true onset (wide log window) and a disproof
+# pass before naming a PR. See SKILL.md.
+set -euo pipefail
+
+file="${1:?usage: attribute_pr.sh <file> <line> [git-ref]}"
+line="${2:?usage: attribute_pr.sh <file> <line> [git-ref]}"
+ref="${3:-origin/master}"
+
+sha=$(git blame -L "${line},${line}" "$ref" -- "$file" | awk '{print $1}' | tr -d '^')
+echo "line:   ${file}:${line} (@ ${ref})"
+echo "commit: ${sha}"
+git show -s --format='        %an  %ci%n        %s' "$sha"
+
+owner_repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || echo "")
+echo "PR(s) containing this commit:"
+if [ -n "$owner_repo" ]; then
+  gh api "repos/${owner_repo}/commits/${sha}/pulls" \
+    --jq '.[] | "        #\(.number)  \(.title)  — \(.html_url)"' 2>/dev/null \
+    || echo "        (none found via API)"
+else
+  echo "        (could not resolve repo; run inside a gh-authenticated checkout)"
+fi

--- a/claude/skills/send-gchat-message/SKILL.md
+++ b/claude/skills/send-gchat-message/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: send-gchat-message
+description: Send a message to one or more Google Chat spaces, resolving raw space IDs or team identifiers (@vendasta/<team> or a team slug) to space IDs. Low-level primitive used by notify-pr-channels and other skills that need to post to Chat. Use when you need to deliver an arbitrary message to a Chat channel/team, or when another skill asks to "post to the team's channel".
+---
+
+# Send Google Chat Message
+
+A small, reusable primitive for posting a message to Google Chat. It owns
+**auth** and **channel resolution** so callers don't reimplement either.
+`notify-pr-channels` delegates its actual sending here; `regression-triage`
+uses it to alert the team that owns a buggy PR.
+
+## What it does
+
+- Resolves each target to a space ID:
+  - **raw space ID** (e.g. `AAAAIj8WMWc`) → used as-is
+  - **team slug** (`phoenix`) or **GitHub team handle** (`@vendasta/phoenix`) → looked up in `TEAM_CHANNELS`
+  - **unmapped team** → live `spaces.list` fallback matching a space named `Team: <Name>`
+- Posts the same message text to every resolved target.
+- Optionally appends `<users/...>` mentions.
+
+## Usage
+
+```bash
+SCRIPT=~/.claude/skills/send-gchat-message/scripts/send_gchat.py
+
+# Post to one or more teams/spaces (mix freely):
+python3 "$SCRIPT" --targets "phoenix,marina" --message "heads up: ..."
+
+# GitHub team handle form, body from a file (use a file for multi-line/markdown):
+python3 "$SCRIPT" --targets "@vendasta/phoenix" --message-file /tmp/msg.md
+
+# Just resolve targets to space IDs without sending (useful for a review gate):
+python3 "$SCRIPT" --targets "phoenix,some-new-team" --resolve-only
+
+# Add @mentions by user ID:
+python3 "$SCRIPT" --targets "meerkats" --message "PR ready" \
+  --mention "users/101609381686230694100,users/107059066615888383168"
+```
+
+Always write multi-line / markdown messages to a file and use `--message-file`
+(shell heredoc quoting is fragile).
+
+## Resolution & the channel map
+
+`TEAM_CHANNELS` in `scripts/send_gchat.py` is the **single source of truth** for
+team→space IDs. When a team isn't in the map, the script discovers it live by
+listing the authenticated user's spaces and matching `displayName == "Team: <slug>"`.
+When you discover a new team this way, paste its `slug: space_id` into
+`TEAM_CHANNELS` so future runs skip the lookup.
+
+Importing from another skill:
+
+```python
+import sys, os
+sys.path.insert(0, os.path.expanduser('~/.claude/skills/send-gchat-message/scripts'))
+import send_gchat
+token = send_gchat.get_access_token()
+sid, how = send_gchat.resolve_target('@vendasta/phoenix', token)
+send_gchat.post_message(token, sid, "hello")
+```
+
+## Auth
+
+OAuth via GCP secret `google-chat-oauth-client-secret` (project `repcore-prod`),
+cached refresh token at `~/.config/google-chat-cli/credentials-rw.json`. No
+webhook URLs. Interactive-only auth means this may be unavailable in fully
+headless/cron contexts.
+
+## Notes
+
+- `--resolve-only` is the right call before an outward-facing send when you want
+  to confirm targets in a review gate first.
+- Resolving an individual **person** (GitHub username → Chat user ID) is not
+  supported — only teams/channels. Pass known `users/...` IDs via `--mention`.

--- a/claude/skills/send-gchat-message/scripts/send_gchat.py
+++ b/claude/skills/send-gchat-message/scripts/send_gchat.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Send a message to one or more Google Chat spaces.
+
+Reusable primitive: resolves raw space IDs directly, or team identifiers
+(`@vendasta/<slug>` or `<slug>`) to space IDs via TEAM_CHANNELS, falling back to
+a live `spaces.list` "Team: <Name>" displayName lookup. notify-pr-channels and
+other skills import this module so auth + channel resolution live in one place.
+
+Usage:
+  send_gchat.py --targets "phoenix,marina,AAAAIj8WMWc" --message "text"
+  send_gchat.py --targets "@vendasta/phoenix" --message-file body.md
+  send_gchat.py --targets "phoenix" --resolve-only          # print resolution, do not send
+  send_gchat.py --targets "meerkats" --message "..." --mention "users/101...,users/107..."
+
+Auth: OAuth via GCP secret google-chat-oauth-client-secret (repcore-prod),
+cached refresh token at ~/.config/google-chat-cli/credentials-rw.json.
+"""
+import argparse
+import json
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+CLIENT_ID = "642433220657-955eqfa32mlb0o3koe8g4qmuv1ue414s.apps.googleusercontent.com"
+CREDS_FILE = Path.home() / ".config/google-chat-cli/credentials-rw.json"
+
+# Team slug -> Google Chat space ID. Single source of truth for team channel
+# resolution (notify-pr-channels imports this). Unmapped teams are resolved live
+# via spaces.list ("Team: <Name>") and can be pasted back here to skip the lookup.
+TEAM_CHANNELS = {
+    "meerkats":                            "AAAAIj8WMWc",  # personal team PR channel (Craig + Daniel)
+    "snapcats":                            "AAAAAHjNt6A",
+    "snack-ops":                           "AAAAjno8gDs",
+    "phoenix":                             "AAAAN_I9hG8",
+    "marina":                              "AAAABIynxDE",  # discovered via spaces.list 2026-06-24
+    "autobots":                            "AAAAWOyaLAg",
+    "np-easy":                             "AAAAqGa-a8I",
+    "warped-tour":                         "AAQANVVa_PA",
+    "marketplace-institute-of-technology": "AAAACpnkUis",
+}
+
+
+def get_access_token():
+    client_secret = subprocess.run(
+        ['gcloud', 'secrets', 'versions', 'access', 'latest',
+         '--secret=google-chat-oauth-client-secret', '--project=repcore-prod'],
+        capture_output=True, text=True,
+    ).stdout.strip()
+    creds = json.loads(CREDS_FILE.read_text())
+    data = urllib.parse.urlencode({
+        'client_id': CLIENT_ID, 'client_secret': client_secret,
+        'refresh_token': creds['refresh_token'], 'grant_type': 'refresh_token',
+    }).encode()
+    resp = json.loads(urllib.request.urlopen(
+        urllib.request.Request('https://oauth2.googleapis.com/token', data=data, method='POST')
+    ).read())
+    return resp['access_token']
+
+
+def _looks_like_space_id(s):
+    # Space IDs are opaque mixed-case tokens (AAAAIj8WMWc, AAQANVVa_PA); team slugs
+    # are lowercase-with-dashes. An uppercase char means it's a raw space ID.
+    return bool(re.fullmatch(r'[A-Za-z0-9_-]{6,}', s)) and any(c.isupper() for c in s)
+
+
+def _list_spaces(token):
+    spaces, page = [], ''
+    for _ in range(10):
+        url = 'https://chat.googleapis.com/v1/spaces?pageSize=1000' + (('&pageToken=' + page) if page else '')
+        req = urllib.request.Request(url)
+        req.add_header('Authorization', 'Bearer ' + token)
+        d = json.loads(urllib.request.urlopen(req).read())
+        spaces += d.get('spaces', [])
+        page = d.get('nextPageToken', '')
+        if not page:
+            break
+    return spaces
+
+
+def resolve_target(target, token=None):
+    """Resolve a target to (space_id, how). Accepts a raw space ID, a team slug,
+    or @vendasta/<slug>. `how` is one of: raw, map, lookup, unresolved."""
+    t = target.strip()
+    m = re.match(r'@?vendasta/([\w-]+)$', t)
+    if m:
+        t = m.group(1)
+    if _looks_like_space_id(t):
+        return t, 'raw'
+    slug = t.lower()
+    if slug in TEAM_CHANNELS:
+        return TEAM_CHANNELS[slug], 'map'
+    # Live fallback: match a space named "Team: <slug words>".
+    if token is None:
+        token = get_access_token()
+    want = slug.replace('-', ' ')
+    for s in _list_spaces(token):
+        name = (s.get('displayName') or '').strip().lower()
+        if name == f"team: {want}" or (name.startswith('team:') and want in name):
+            return s['name'].split('/')[-1], 'lookup'
+    return None, 'unresolved'
+
+
+def post_message(token, space_id, text):
+    """Post text to a space. Returns (ok, error_string_or_None)."""
+    body = json.dumps({'text': text}).encode()
+    req = urllib.request.Request(
+        f'https://chat.googleapis.com/v1/spaces/{space_id}/messages', data=body, method='POST')
+    req.add_header('Authorization', 'Bearer ' + token)
+    req.add_header('Content-Type', 'application/json')
+    try:
+        urllib.request.urlopen(req).read()
+        return True, None
+    except urllib.error.HTTPError as e:
+        return False, f"{e.code} {e.read().decode()[:300]}"
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Send a Google Chat message to spaces/teams.")
+    ap.add_argument('--targets', required=True,
+                    help='comma-separated space IDs / team slugs / @vendasta/<team>')
+    ap.add_argument('--message', help='message text')
+    ap.add_argument('--message-file', help='read message text from this file')
+    ap.add_argument('--mention', default='',
+                    help='comma-separated user IDs (users/123...) appended as <users/...> mentions')
+    ap.add_argument('--resolve-only', action='store_true',
+                    help='print target resolution and exit without sending')
+    args = ap.parse_args()
+
+    targets = [t for t in args.targets.split(',') if t.strip()]
+    token = get_access_token()
+
+    resolved = []
+    for t in targets:
+        sid, how = resolve_target(t, token)
+        print(f"{t} -> {sid or 'UNRESOLVED'} ({how})")
+        if sid:
+            resolved.append((t, sid))
+
+    if args.resolve_only:
+        return
+
+    text = Path(args.message_file).read_text() if args.message_file else args.message
+    if not text:
+        print("ERROR: --message or --message-file required to send")
+        sys.exit(1)
+    if args.mention:
+        text = text + ' ' + ' '.join(f"<{m.strip()}>" for m in args.mention.split(',') if m.strip())
+
+    failures = 0
+    for t, sid in resolved:
+        ok, err = post_message(token, sid, text)
+        print(f"{'posted' if ok else 'ERROR'} -> {t} ({sid})" + (f": {err}" if err else ''))
+        failures += 0 if ok else 1
+    if failures:
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

Adds a **regression-triage** workflow and decomposes Google Chat sending into a reusable primitive, so the deploy-monitor → find-bug → attribute → alert-or-fix loop is a real, documented chain of skills.

## What's here

- **`send-gchat-message`** (new primitive) — posts to any Chat space/team, resolving raw space IDs, team slugs, and `@vendasta/<team>` handles (map + live `spaces.list` fallback). Owns Chat auth + the `TEAM_CHANNELS` map.
- **`notify-pr-channels`** (refactor) — drops its duplicated OAuth/post/map logic and delegates to `send-gchat-message`; adds an optional prefix line for context.
- **`regression-triage`** (new) — attribute a side-finding to the PR that introduced it (with a confirm-gate, since the first blame is often wrong), then route to **alert the owning team** or **fix it**. The fix branch hands off to the existing dev-flow chain rather than wrapping it. Encodes lessons from a real session: wide-window onset check before blaming, Jira-first ordering, the PR-comment template, and guardrails (`--body-file`, don't `--amend` pushed commits, stale LSP after `go generate`, gomock callback signatures).
- **`README` skill-flow diagram** — Mermaid graph of which skill kicks off which (develop → ship → deploy → triage), so the chain is documented and evolves with the skills.

## Notes

- Built directly on a branch in the main checkout (not a worktree) so the skills load live via the `~/.claude` symlink.
- Skill scripts smoke-tested (parse, arg handling, channel resolution, cross-skill import). No live Chat messages were sent during testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
